### PR TITLE
Continous packaging on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,14 @@ jobs:
           }
           # Pass a package id to subsequent steps
           "::set-env name=PACKAGE_ID::$packageId"
+      - name: Build (if build is required)
+        run: |
+          cd $env:PACKAGE_ID
+          if (Test-Path -LiteralPath build.bat) {
+            .\build.bat
+          } else {
+            'Nothing to build'
+          }
       - name: Package
         run: Write-Host "Packaging $env:PACKAGE_ID"
       - name: Publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   MSYS2_ROOT: 'C:\msys64'
 
 jobs:
-  init:
+  build:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
@@ -25,16 +25,21 @@ jobs:
           $PSVersionTable
           git --version
           choco --version
+          env | grep -i 'github\|runner' | sort
+          '${{ toJson(github) }}'
       - name: Detect a target package # from a tag name or a branch name
         run: |
           if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch') {
             # Overwrite GITHUB_REF with a trigger input
             $env:GITHUB_REF = '${{ github.event.inputs.git_ref }}'
           }
+          ## Extract package id from ref
           $refs = $env:GITHUB_REF -split '/'
           if ($refs[1] -eq 'tags') {
+            # Tag like "refs/tags/<package_id>/<package_version>"
             $packageId = $refs[2]
-          } else if (($refs[1] -eq 'heads') -and ($res[2] -eq 'package')) {
+          } elseif (($refs[1] -eq 'heads') -and ($refs[2] -eq 'package')) {
+            # Branch like "refs/heads/package/<package_id>"
             $packageId = $refs[3]
           } else {
             $message = 'Cannot extract a package id from ref "{0}"' -f $env:GITHUB_REF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
 env:
   MINGW_ROOT: 'C:\MinGW'
   MSYS2_ROOT: 'C:\msys64'
+  PYTHON27_ROOT: 'C:\hostedtoolcache\windows\Python\2.7.18\x64'
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Continuous Build
+name: Continuous Packaging
 
 on:
   workflow_dispatch: # Enable manual trigger

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Build
 on:
   workflow_dispatch: # Enable manual trigger
     inputs:
-      refs:
+      git_ref:
         description: Reference of git (like refs/heads/master or refs/tags/v1.0.0)
         required: true
   push:
@@ -29,7 +29,7 @@ jobs:
         run: |
           if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch') {
             # Overwrite GITHUB_REF with a trigger input
-            $env:GITHUB_REF = '${{ github.event.inputs.refs }}'
+            $env:GITHUB_REF = '${{ github.event.inputs.git_ref }}'
           }
           $refs = $env:GITHUB_REF -split '/'
           if ($refs[1] -eq 'tags') {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,7 @@ jobs:
             Write-Error -Message $message
             exit 1
           }
-          'Package:{0},Version:{1}' -f $env:PACKAGE_ID, $env:PACKAGE_VERSION
-  package:
-    runs-on: windows-2019
-    steps:
-      - run: echo Packaging
-  publish:
-    runs-on: windows-2019
-    steps:
-      - run: echo Publishing
+      - name: Package
+        run: Write-Host "Packaging $env:PACKAGE_ID"
+      - name: Publish
+        run: Write-Host "Publishing $env:PACKAGE_ID"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: Continuous Build
 
 on:
   workflow_dispatch: # Enable manual trigger
+    inputs:
+      refs:
+        description: Reference of git (like refs/heads/master or refs/tags/v1.0.0)
+        required: true
   push:
     branches: 'package/*'
     tags: '*'
@@ -23,6 +27,10 @@ jobs:
           choco --version
       - name: Detect a target package # from a tag name or a branch name
         run: |
+          if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch') {
+            # Overwrite GITHUB_REF with a trigger input
+            $env:GITHUB_REF = '${{ github.event.inputs.refs }}'
+          }
           $refs = $env:GITHUB_REF -split '/'
           if ($refs[1] -eq 'tags') {
             $packageId = $refs[2]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           $PSVersionTable
           git --version
           choco --version
-          env | grep -i 'github\|runner' | sort
+          cmd /c "set" | grep -i 'github\|runner' | sort
           '${{ toJson(github) }}'
       - name: Detect a target package # from a tag name or a branch name
         run: |
@@ -54,7 +54,8 @@ jobs:
           }
           # Pass a package id to subsequent steps
           "::set-env name=PACKAGE_ID::$packageId"
-      - name: Build (if build is required)
+      - name: Build (if needed)
+        working-directory: ${{ env.PACKAGE_ID }}
         run: |
           if (Test-Path -LiteralPath build.bat) {
             # Add mingw toolchains into PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,11 @@ jobs:
             'Nothing to build'
           }
       - name: Package
-        run: Write-Host "Packaging $env:PACKAGE_ID"
+        working-directory: ${{ env.PACKAGE_ID }}
+        run: |
+          choco pack
+          if (Test-Path -LiteralPath test.bat) {
+            .\test.bat
+          }
       - name: Publish
         run: Write-Host "Publishing $env:PACKAGE_ID"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,5 +71,10 @@ jobs:
           if (Test-Path -LiteralPath test.bat) {
             .\test.bat
           }
+      - name: Save a package as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.PACKAGE_ID }}_package
+          path: '**/*.nupkg'
       - name: Publish
         run: Write-Host "Publishing $env:PACKAGE_ID"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,4 +77,5 @@ jobs:
           name: ${{ env.PACKAGE_ID }}_package
           path: '**/*.nupkg'
       - name: Publish
-        run: Write-Host "Publishing $env:PACKAGE_ID"
+        working-directory: ${{ env.PACKAGE_ID }}
+        run: choco push --source https://www.myget.org/F/kai2nenobu/ --api-key ${{ secrets.MYGET_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
     tags: '*'
 
 env:
-  MINGW_ROOT: 'C:\MinGW'
+  MINGW_ROOT: 'C:\msys64\mingw32'
   MSYS2_ROOT: 'C:\msys64'
   PYTHON27_ROOT: 'C:\hostedtoolcache\windows\Python\2.7.18\x64'
 
@@ -56,8 +56,9 @@ jobs:
           "::set-env name=PACKAGE_ID::$packageId"
       - name: Build (if build is required)
         run: |
-          cd $env:PACKAGE_ID
           if (Test-Path -LiteralPath build.bat) {
+            # Add mingw toolchains into PATH
+            $env:PATH = "${env:MINGW_ROOT}/bin;${env:MSYS2_ROOT}/bin;${env:PATH}"
             .\build.bat
           } else {
             'Nothing to build'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
             Write-Error -Message $message
             exit 1
           }
+          if (-not (Test-Path -LiteralPath $packageId)) {
+            $message = 'Directory for package "{0}" not found' -f $packageId
+            Write-Error -Message $message
+            exit 1
+          }
+          # Pass a package id to subsequent steps
+          "::set-env name=PACKAGE_ID::$packageId"
       - name: Package
         run: Write-Host "Packaging $env:PACKAGE_ID"
       - name: Publish

--- a/mozc-emacs-helper/build.bat
+++ b/mozc-emacs-helper/build.bat
@@ -10,10 +10,10 @@ REM Install requirements
 choco install ninja --version 1.7.2 --yes
 
 REM Checkout source
-"%GIT_COMMAND%" clone "%MOZC_REPOSITORY%" -b master --single-branch
+"%GIT_COMMAND%" clone "%MOZC_REPOSITORY%" -b master --single-branch --depth 1
 cd mozc
 "%GIT_COMMAND%" checkout "%COMMIT_HASH%"
-"%GIT_COMMAND%" submodule update --init --recursive
+"%GIT_COMMAND%" submodule update --init --recursive --depth 1
 
 REM Build mozc
 "%PATCH_COMMAND%" -p1 < ..\win32_build.patch

--- a/mozc-emacs-helper/build.bat
+++ b/mozc-emacs-helper/build.bat
@@ -5,6 +5,8 @@ set PATCH_COMMAND=%MSYS2_ROOT%\usr\bin\patch
 
 set MOZC_REPOSITORY=https://github.com/google/mozc.git
 set COMMIT_HASH=afb03ddfe72dde4cf2409863a3bfea160f7a66d8
+REM Use python 2.7
+set PATH=%PYTHON27_ROOT%;%PATH%
 
 REM Install requirements
 choco install ninja --version 1.7.2 --yes


### PR DESCRIPTION
AUで自動アップデートするわけではないパッケージも、GitHub ActionsのCIで回すようにする。

実行ファイルビルドやパッケージング、パッケージの公開までの一通りの動作はできるようになった。
ブランチ名の規則は `package/<package_id>`、タグ名の規則は`<package_id>/<package_version>` というのは変えていない。

ただし mozc-emacs-helper の実行ファイルビルドはGitHub Actionsのランナーの環境ではビルドできなかった。(#48)
が、そもそもmozcは最近更新がなく再度mozc-emacs-helperをビルドしたい、ということもないかもしれないのでひとまず気にせずマージすることにする。
 