### PR TITLE
Support a self-extracting zip for Pleiades

### DIFF
--- a/pleiades-streams/tools/chocolateyInstall.ps1
+++ b/pleiades-streams/tools/chocolateyInstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop'; # stop on all errors
+$ErrorActionPreference = 'Stop'; # stop on all errors
 
 $packageName = 'pleiades-platform'
 $installPath = Join-Path (Get-ToolsLocation) $packageName
@@ -17,7 +17,7 @@ Install-ChocolateyZipPackage `
 
 ## Create a shortcut to eclipse.exe
 $CommonPrograms =([Environment]::GetFolderPath('CommonPrograms'))
-$executable = Join-Path $installPath 'pleiades/eclipse/eclipse.exe'
+$executable = Join-Path $installPath 'eclipse/eclipse.exe'
 $workdir = Split-Path $executable -Parent
 $shortcut = Join-Path $CommonPrograms "$packageName/$shortcutName"
 Install-ChocolateyShortcut `

--- a/pleiades-streams/tools/chocolateyInstall.ps1
+++ b/pleiades-streams/tools/chocolateyInstall.ps1
@@ -12,11 +12,11 @@ Install-ChocolateyZipPackage `
   -PackageName $packageName `
   -Url $url `
   -Checksum $checksum `
-  -ChecksumType $checkstumType `
+  -ChecksumType $checksumType `
   -UnzipLocation $installPath
 
 ## Create a shortcut to eclipse.exe
-$CommonPrograms =([Environment]::GetFolderPath('CommonPrograms'))
+$CommonPrograms = ([Environment]::GetFolderPath('CommonPrograms'))
 $executable = Join-Path $installPath 'eclipse/eclipse.exe'
 $workdir = Split-Path $executable -Parent
 $shortcut = Join-Path $CommonPrograms "$packageName/$shortcutName"

--- a/pleiades-streams/update_helper.ps1
+++ b/pleiades-streams/update_helper.ps1
@@ -30,10 +30,10 @@ function Find-PleiadesVersion {
   }
 }
 
-function Get-PleiadesZipUrl {
+function Get-PleiadesArchiveUrl {
   <#
   .SYNOPSIS
-  Format a download URL for pleiades zip
+  Format a download URL for pleiades archive
   #>
   [CmdletBinding()]
   param(
@@ -50,7 +50,7 @@ function Get-PleiadesZipUrl {
   else {
     $formatParams += ''
   }
-  return 'https://ftp.jaist.ac.jp/pub/mergedoc/pleiades/{0}/pleiades-{0}-{1}-{3}-win-64bit{4}_{2}.zip' -f $formatParams
+  return 'https://ftp.jaist.ac.jp/pub/mergedoc/pleiades/{0}/pleiades-{0}-{1}-{3}-win-64bit{4}_{2}.exe' -f $formatParams
 }
 
 function Get-PleiadesTitle {
@@ -89,7 +89,7 @@ function Get-PleiadesStream {
   $full = $StreamName -match '-full$'
   return @{
     PackageName = "pleiades-$StreamName"
-    URL64       = (Get-PleiadesZipUrl -Name $name -VersionArray $VersionArray -FullEdition $full)
+    URL64       = (Get-PleiadesArchiveUrl -Name $name -VersionArray $VersionArray -FullEdition $full)
     Title       = (Get-PleiadesTitle -Name $name -FullEdition $full)
   }
 }


### PR DESCRIPTION
Fix #62

Because a self-extracting zip for pleiades is a valid zip, chocolatey can expand it by `Install-ChocolateyZipPackage`.